### PR TITLE
Memory usage fix

### DIFF
--- a/include/rpq_solver.hpp
+++ b/include/rpq_solver.hpp
@@ -1001,7 +1001,7 @@ namespace rpq {
 
         explicit solver(const std::string &dataset, const std::string &index,
                         const uint n_preds, const uint n_triples)
-            : m_predicate_offset(static_cast<uint64_t>(n_preds) + 1){
+            : m_predicate_offset(n_preds){
 
             m_matrices.resize(n_preds + 1);
             uint64_t space = 0;

--- a/include/rpq_solver.hpp
+++ b/include/rpq_solver.hpp
@@ -5,10 +5,6 @@
 #ifndef MATRIX_RPQ_RPQ_SOLVER_HPP
 #define MATRIX_RPQ_RPQ_SOLVER_HPP
 
-#define N 958844164
-#define SIZE 5420 // 1 to 5419
-#define V 296008192 // 1 to...
-
 #ifndef w
 #define w (8*sizeof(uint64_t))
 #endif
@@ -45,6 +41,7 @@ namespace rpq {
         //std::vector<matrix> m_tmp_matrices;
         std::unordered_map<std::string, uint64_t> m_map_SO;
         std::unordered_map<std::string, uint64_t> m_map_P;
+        uint64_t m_predicate_offset;
 
 
         inline matrix get_matrix(s_matrix &a, matrix m, bool is_tranposed){
@@ -57,9 +54,9 @@ namespace rpq {
                        bool skip_closure = false){
             switch(node->type) {
                 case STR:{
-                    auto pred = rpqTree->getPred(node->pos);
-                    matrix a = (pred > SIZE) ? m_matrices[pred-SIZE] :  m_matrices[pred];
-                    res.insert(res.begin(), data_type{a, (pred > SIZE),
+                    uint64_t pred = static_cast<uint64_t>(rpqTree->getPred(node->pos));
+                    matrix a = (pred > m_predicate_offset) ? m_matrices[pred-m_predicate_offset] :  m_matrices[pred];
+                    res.insert(res.begin(), data_type{a, (pred > m_predicate_offset),
                                                       false, false});
                     break;
                 }
@@ -244,15 +241,15 @@ namespace rpq {
                                  bool skip_closure = false){
             switch(node->type) {
                 case STR:{
-                    auto pred = rpqTree->getPred(node->pos);
+                    uint64_t pred = static_cast<uint64_t>(rpqTree->getPred(node->pos));
                     if(parentType != ROOT){
-                        matrix a = (pred > SIZE) ? m_matrices[pred-SIZE] :  m_matrices[pred];
-                        res.insert(res.begin(), data_type{a, (pred > SIZE), false, false});
+                        matrix a = (pred > m_predicate_offset) ? m_matrices[pred-m_predicate_offset] :  m_matrices[pred];
+                        res.insert(res.begin(), data_type{a, (pred > m_predicate_offset), false, false});
                     }else {
-                        matrix a = (pred > SIZE) ? m_matrices[pred-SIZE] :  m_matrices[pred];
+                        matrix a = (pred > m_predicate_offset) ? m_matrices[pred-m_predicate_offset] :  m_matrices[pred];
                         matrix A;
                         s_matrix sA;
-                        A = get_matrix(sA, a, (pred > SIZE));
+                        A = get_matrix(sA, a, (pred > m_predicate_offset));
                         matrix e = wrapper::empty(A->height, A->width);
                         matrix m = wrapper::sum1(wrapper::full_side, A, e, col);
                         wrapper::destroy(e);
@@ -504,15 +501,15 @@ namespace rpq {
                                  bool skip_closure = false){
             switch(node->type) {
                 case STR:{
-                    auto pred = rpqTree->getPred(node->pos);
+                    uint64_t pred = static_cast<uint64_t>(rpqTree->getPred(node->pos));
                     if(parentType != ROOT){
-                        matrix a = (pred > SIZE) ? m_matrices[pred-SIZE] :  m_matrices[pred];
-                        res.insert(res.begin(), data_type{a, (pred > SIZE), false, false});
+                        matrix a = (pred > m_predicate_offset) ? m_matrices[pred-m_predicate_offset] :  m_matrices[pred];
+                        res.insert(res.begin(), data_type{a, (pred > m_predicate_offset), false, false});
                     }else {
                         matrix A;
                         s_matrix sA;
-                        matrix a = (pred > SIZE) ? m_matrices[pred-SIZE] :  m_matrices[pred];
-                        A = get_matrix(sA, a, (pred > SIZE));
+                        matrix a = (pred > m_predicate_offset) ? m_matrices[pred-m_predicate_offset] :  m_matrices[pred];
+                        A = get_matrix(sA, a, (pred > m_predicate_offset));
                         matrix e = wrapper::empty(A->height, A->width);
                         matrix m = wrapper::sum1(row, A, e, wrapper::full_side);
                         wrapper::destroy(e);
@@ -742,15 +739,15 @@ namespace rpq {
                                      bool skip_closure = false){
             switch(node->type) {
                 case STR:{
-                    auto pred = rpqTree->getPred(node->pos);
+                    uint64_t pred = static_cast<uint64_t>(rpqTree->getPred(node->pos));
                     if(parentType != ROOT){
-                        matrix a = (pred > SIZE) ? m_matrices[pred-SIZE] :  m_matrices[pred];
-                        res.insert(res.begin(), data_type{a, (pred > SIZE), false, false});
+                        matrix a = (pred > m_predicate_offset) ? m_matrices[pred-m_predicate_offset] :  m_matrices[pred];
+                        res.insert(res.begin(), data_type{a, (pred > m_predicate_offset), false, false});
                     }else {
                         matrix A;
                         s_matrix sA;
-                        matrix a = (pred > SIZE) ? m_matrices[pred-SIZE] :  m_matrices[pred];
-                        A = get_matrix(sA, a, (pred > SIZE));
+                        matrix a = (pred > m_predicate_offset) ? m_matrices[pred-m_predicate_offset] :  m_matrices[pred];
+                        A = get_matrix(sA, a, (pred > m_predicate_offset));
                         matrix e = wrapper::empty(A->height, A->width);
                         matrix m = wrapper::sum1(row, A, e, col);
                         wrapper::destroy(e);
@@ -1003,7 +1000,8 @@ namespace rpq {
         std::unordered_map<std::string, uint64_t> &map_P = m_map_P;
 
         explicit solver(const std::string &dataset, const std::string &index,
-                        const uint n_preds, const uint n_triples){
+                        const uint n_preds, const uint n_triples)
+            : m_predicate_offset(static_cast<uint64_t>(n_preds) + 1){
 
             m_matrices.resize(n_preds + 1);
             uint64_t space = 0;
@@ -1044,12 +1042,12 @@ namespace rpq {
             }
             std::cout << " done." << std::endl;
 
-            /*double_t bits = std::ceil(std::log2(N)) * (SIZE-1);
+            /*double_t bits = std::ceil(std::log2(n_triples)) * (m_predicate_offset-1);
             for(uint64_t j = 1; j < m_matrices.size(); ++j){
                 bits = bits + std::ceil(std::log2(m_matrices[j]->elems)) * m_matrices[j]->elems;
             }
             double_t bytes = bits / 8;
-            double_t bpt = bytes / N;
+            double_t bpt = bytes / n_triples;
             std::cout << "====== VP =====" << std::endl;
             std::cout << bits << " (bits)" << std::endl;
             std::cout << bytes << " (bytes)" << std::endl;
@@ -1059,28 +1057,28 @@ namespace rpq {
 
         data_type solve_var_to_var(std::string &query, bool &rem){
             list_type res;
-            RpqTree rpqTree(query, map_P, m_matrices.size());
+            RpqTree rpqTree(query, map_P, m_predicate_offset);
             traversal(&rpqTree, rpqTree.root(), ROOT, res);
             return res.front();
         }
 
         data_type solve_con_to_var(std::string &query, int s_id, bool &rem){
             list_type res;
-            RpqTree rpqTree(query, map_P, m_matrices.size());
+            RpqTree rpqTree(query, map_P, m_predicate_offset);
             traversal_row_fixed(&rpqTree, rpqTree.root(), ROOT, s_id, res);
             return res.front();
         }
 
         data_type solve_var_to_con(std::string &query, int o_id, bool &rem){
             list_type res;
-            RpqTree rpqTree(query, map_P, m_matrices.size());
+            RpqTree rpqTree(query, map_P, m_predicate_offset);
             traversal_col_fixed(&rpqTree, rpqTree.root(), ROOT, o_id, res);
             return res.front();
         }
 
         data_type solve_con_to_con(std::string &query, int s_id, int o_id, bool &rem){
             list_type res;
-            RpqTree rpqTree(query, map_P, m_matrices.size());
+            RpqTree rpqTree(query, map_P, m_predicate_offset);
             traversal_row_col_fixed(&rpqTree, rpqTree.root(), ROOT, s_id, o_id, res);
             return res.front();
         }

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -188,8 +188,8 @@ namespace rpq {
         uint64_t i = 1;
         uint64_t elems;
         std::ifstream ifs_q(queries);
-        do{
-            getline(ifs_q, line);
+        while (getline(ifs_q, line)){
+            if (line.empty()) continue;
             l2 = line;
             query.clear();
 
@@ -229,7 +229,7 @@ namespace rpq {
                 }
             }
             ++i;
-        }while(!ifs_q.eof());
+        }
         ifs_q.close();
     }
 }

--- a/lib/baseline_gn/src/baseline/hash.c
+++ b/lib/baseline_gn/src/baseline/hash.c
@@ -26,13 +26,13 @@ extern inline void hashInsert (hashTable hash, uint key, uint val)
 hashTable hashCreate (uint *values, uint n)
 
    { hashTable hash;
-     uint i;
-     hash.b = (((uint)1) << (1+numbits(n)))-1;
-     hash.table = (uint*)myalloc(hash.b*sizeof(uint));
-     hash.sat = (uint*)myalloc(hash.b*sizeof(uint));
-     for (i=0;i<hash.b;i++) hash.table[i] = ~0;
-     for (i=0;i<n;i++) hashInsert (hash,values[i],i);
-     return hash;
+    uint size = 1 << (1 + numbits(n));
+    hash.b = size - 1;
+    hash.table = (uint*)myalloc(size * sizeof(uint));
+    hash.sat   = (uint*)myalloc(size * sizeof(uint));
+    for (uint i = 0; i < size; i++) hash.table[i] = ~0;
+    for (uint i = 0; i < n; i++) hashInsert(hash, values[i], i);
+    return hash;
    }
 
 void hashDestroy (hashTable hash)

--- a/lib/baseline_gn/src/baseline/matrix.c
+++ b/lib/baseline_gn/src/baseline/matrix.c
@@ -728,7 +728,7 @@ matrix matMult (matrix A, matrix B)
     }
     task = (ttask*)myrealloc(task,p*sizeof(ttask));
     Hr = (heap)myalloc(p*sizeof(struct s_heap)); // to merge rows
-    Hc = (heap)myalloc(p*sizeof(struct s_heap)); // to merge columns
+    Hc = (heap)myalloc((B->width)*sizeof(struct s_heap)); // to merge columns
 
     // we first fill M in row-wise form
     matrix M = (matrix)myalloc(sizeof(struct s_matrix));


### PR DESCRIPTION
Hello. I noticed that sometimes I got memory usage errors during RPQ solving. For example here I'm trying to solve 10 RPQs :
```
Reading 9 matrices... done... 84061 total words (10.67 bpt)
Reading mapping... done.
<references><cite><creator>
1;43412;6867084
<references><cite><creator>|<creator><coauthor><coauthor>
2;43461;6519260
(<coauthor>)*
3;24362;3169201
(<coauthor>)*<predecessor>
4;28;2969576
(<coauthor>)+
5;136;449023
(<references><cite>)*
6;32320;6788118
<partOf><editor>(<predecessor>|<coauthor>)
7;1711;226583
<partOf><editor>(<predecessor>|<coauthor>)*
free(): invalid next size (fast)
Aborted (core dumped)
```
Valgrind showed that there are a little bit of errors:
```
==96939== LEAK SUMMARY:
==96939==    definitely lost: 6,328 bytes in 19 blocks
==96939==    indirectly lost: 677,212 bytes in 94 blocks
==96939==      possibly lost: 0 bytes in 0 blocks
==96939==    still reachable: 0 bytes in 0 blocks
==96939==         suppressed: 0 bytes in 0 blocks
==96939== 
==96939== For lists of detected and suppressed errors, rerun with: -s
==96939== ERROR SUMMARY: 42231 errors from 29 contexts 
```
So I found that some functions cause a incorrect memory usage:
```
==96939== Use of uninitialised value of size 8
==96939==    at 0x126BDC: matMult.part.0 (in 
```
```
 by 0x1184EA: main (baseline_query.cpp:37)
==96939==  Uninitialised value was created by a heap allocation
==96939==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==96939==    by 0x12BC91: myalloc (in /media/rpq/rpq/rpq_mem_fix/build/baseline_query)
==96939==    by 0x126912: matMult.part.0 (in /media/rpq/rpq/rpq_mem_fix/build/baseline_query)
==96939==    by 0x119D00: mult (bm_baseline.hpp:103)

=96939== Invalid read of size 4
==96939==    at 0x12BB2C: hashSearch (in /media/rpq/rpq/rpq_mem_fix/build/baseline_query)
==96939==    by 0x1261A5: strongconnect (in /media/rpq/rpq/rpq_mem_fix/build/baseline_query)
==96939==    by 0x1274C4: strongly (in /media/rpq/rpq/rpq_mem_fix/build/baseline_query)
==96939==    by 0x12B7C2: matClos (in /media/rpq/rpq/rpq_mem_fix/build/baseline_query)

==96939== Invalid write of size 8
==96939==    at 0x126AF9: matMult.part.0 (in /media/rpq/rpq/rpq_mem_fix/build/baseline_query)
==96939==    by 0x119D00: mult (bm_baseline.hpp:103)
```
So I made a little fix that solved program failures for me!
You can test it on your machine.

I think new versions of the compiler have become more strict about UB, this is the reason why it have worked before but not today.